### PR TITLE
fixed sendRequest

### DIFF
--- a/chrome/Extension.hx
+++ b/chrome/Extension.hx
@@ -18,7 +18,9 @@ private typedef FetchProperties = {
 	static function getViews( ?fetchProperties : FetchProperties ) : Array<js.Window>;
 	static function isAllowedFileSchemeAccess( cb : Bool->Void ) : Void;
 	static function isAllowedIncognitoAccess( cb : Bool->Void ) : Void;
-	static function sendRequest( ?extensionId : String, request : Dynamic, ?responseCallback : Dynamic->Void ) : Void;
+	
+	@:overload(function( ?extensionId : String, request : Dynamic, ?responseCallback : Dynamic->Void ) : Void {} )
+	static function sendRequest( request : Dynamic, ?responseCallback : Dynamic->Void ) : Void;
 	
 	static var onConnect(default,null) : chrome.Event<Port->Void>;
 	static var onConnectExternal(default,null) : chrome.Event<Port->Void>;


### PR DESCRIPTION
There is a bug on the extern _Extension.hx_, which causes:

```
chrome.Extension.sendRequest(true, function(response) {});
```

being compiled to 

```
chrome.extension.sendRequest(null,true,function(response) {});
```

which lead to the error **Uncaught Error: Invalid arguments to sendRequest.**.

My fix is tested to work on Chrome 18.0.1025.162.
