### PR TITLE
chrome.tabs.create's callback is optional

### DIFF
--- a/src/chrome/Tabs.hx
+++ b/src/chrome/Tabs.hx
@@ -80,7 +80,7 @@ extern class Tabs {
 			?pinned:Bool,
 			?openerTabId:Int
 		},
-		callback : Tab->Void ) : Void;
+		?callback : Tab->Void ) : Void;
 	static function duplicate( tabId : Int, ?callback : Tab->Void ) : Void;
 	static function query(
 		queryInfo : {


### PR DESCRIPTION
According to https://developer.chrome.com/extensions/tabs#method-create